### PR TITLE
Implement a pfSense Web Cli

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+max_line_length = 119
+
+# Use 2 spaces for the HTML files
+[*.html]
+indent_size = 2
+
+# The JSON files contain newlines inconsistently
+[*.json]
+indent_size = 2
+insert_final_newline = ignore
+
+[**/admin/js/vendor/**]
+indent_style = ignore
+indent_size = ignore
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.7
 RUN apk update && \
     apk add py-pip
 
-ADD cli.py /
 ADD requirements.txt /
 RUN pip install -r /requirements.txt
 
+ADD cli.py /
 
 ENTRYPOINT ["python", "/cli.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.7
+
+RUN apk update && \
+    apk add py-pip
+
+ADD cli.py /
+ADD requirements.txt /
+RUN pip install -r /requirements.txt
+
+
+ENTRYPOINT ["python", "/cli.py"]

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2017 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # pfsense-cli
-Mechanized pfSense cli tool in python
+
+This is a simple cli that configures specific settings in pfSense by emulating a web browser using the python mechanize module.
+

--- a/cli.py
+++ b/cli.py
@@ -16,6 +16,7 @@ ssl._create_default_https_context = ssl._create_unverified_context # pylint: dis
 
 pp = pprint.PrettyPrinter(indent=4)
 
+
 class PfSenseWebAPI:
     def __init__(self, debug_level=False):
         self.browser = mechanize.Browser()
@@ -26,13 +27,13 @@ class PfSenseWebAPI:
         if self.debug_level:
             print msg
 
-    def login(self,username,password,host):
+    def login(self, username, password, host):
         self.username = username
         self.password = password
         self.host = host
         self.url = 'https://' + self.host
 
-        response = self.browser.open(self.url + '/index.php')
+        self.browser.open(self.url + '/index.php')
         self.browser.form = list(self.browser.forms())[0]
 
         control = self.browser.form.find_control('usernamefld')
@@ -41,14 +42,14 @@ class PfSenseWebAPI:
         control = self.browser.form.find_control('passwordfld')
         control.value = self.password
 
-        response = self.browser.submit()
+        self.browser.submit()
 
     def wait_until_ready(self):
         while True:
             response = self.browser.open(self.url + '/index.php')
             html = response.read()
             if 'Do not make changes in the GUI' not in html \
-                and 'Packages are currently being reinstalled in the background' not in html:
+                    and 'Packages are currently being reinstalled in the background' not in html:
                 break
             print "pfSense is not ready"
             time.sleep(1)
@@ -59,7 +60,7 @@ class PfSenseWebAPI:
             if 'Snort' in link.text:
                 print "Found link " + link.url
                 self.browser.click_link(link)
-                response = self.browser.follow_link(link)
+                self.browser.follow_link(link)
                 break
         self.browser.form = list(self.browser.forms())[0]
         self.browser.form.set_all_readonly(False)
@@ -71,14 +72,14 @@ class PfSenseWebAPI:
         self.browser.form.find_control("by2toggle").value = ''
 
         response = self.browser.submit()
-        request = self.browser.request
+        self.browser.request
         html = response.read()
         self.debug(html)
 
         return
 
     def set_admin_password(self, new_password):
-        response = self.browser.open(self.url + '/system_usermanager.php?act=edit&userid=0')
+        self.browser.open(self.url + '/system_usermanager.php?act=edit&userid=0')
         self.browser.form = list(self.browser.forms())[0]
         control = self.browser.form.find_control("passwordfld1")
         control.value = new_password
@@ -91,12 +92,11 @@ class PfSenseWebAPI:
 
         return
 
-
     def squidguard_enable(self):
         for link in self.browser.links():
             if 'SquidGuard Proxy Filter' in link.text:
                 self.browser.click_link(link)
-                response = self.browser.follow_link(link)
+                self.browser.follow_link(link)
                 break
 
         self.browser.form = list(self.browser.forms())[0]
@@ -111,19 +111,19 @@ class PfSenseWebAPI:
 
         return
 
-
     def squidguard_download(self):
-        response = self.browser.open(self.url + '/squidGuard/squidguard_blacklist.php')
+        self.browser.open(self.url + '/squidGuard/squidguard_blacklist.php')
         self.browser.form = list(self.browser.forms())[0]
         control = self.browser.form.find_control('blacklist_url')
         blacklist = control.value
         print "Found blacklist: " + blacklist
 
         response = self.browser.submit(name='blacklist_download_start')
-        html = response.read()
+        response.read()
 
         # Start the download
-        response = self.browser.open(self.url + '/squidGuard/squidguard_blacklist.php?getactivity=yes&blacklist_download_start=yes&blacklist_url=' + blacklist)
+        self.browser.open(self.url + '/squidGuard/squidguard_blacklist.php?getactivity=yes'
+                                                '&blacklist_download_start=yes&blacklist_url=' + blacklist)
 
         # Block until completed
         while True:
@@ -140,7 +140,7 @@ class PfSenseWebAPI:
         for link in self.browser.links():
             if 'Backup & Restore' in link.text:
                 self.browser.click_link(link)
-                response = self.browser.follow_link(link)
+                self.browser.follow_link(link)
                 break
 
         self.browser.form = list(self.browser.forms())[0]
@@ -156,7 +156,7 @@ class PfSenseWebAPI:
         for link in self.browser.links():
             if 'Backup & Restore' in link.text:
                 self.browser.click_link(link)
-                response = self.browser.follow_link(link)
+                self.browser.follow_link(link)
                 break
 
         now = int(time.time())
@@ -179,8 +179,10 @@ class PfSenseWebAPI:
         output.close()
         return
 
+
 def main():
-    usage = "usage: %prog [options] [restore-backup|enable-squidguard|squidguard-download|enable-snort|set-admin-password|download-backup]"
+    usage = "usage: %prog [options] [restore-backup|enable-squidguard|squidguard-download|enable-snort|set-admin" \
+            "-password|download-backup] "
     parser = OptionParser(usage)
     parser.add_option("-u", "--username", dest="username",
                       help="login as username")
@@ -238,9 +240,10 @@ def main():
         else:
             raise ValueError('Unrecognized option: ' + action)
 
-    except KeyboardInterrupt as e:
+    except KeyboardInterrupt:
         print "Aborted"
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/cli.py
+++ b/cli.py
@@ -220,12 +220,9 @@ def main():
     api = PfSenseWebAPI(opts.debug_level)
     status, message = api.login(opts.username, opts.password, opts.host)
 
-    if status is not True:
+    if status != 0:
         print (message)
-        sys.exit(2)
-    else:
-        print (message)
-        exit(0)
+        sys.exit(1)
 
     action = args[0]
 

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+import mechanize
+import ssl
+import time
+import os
+import re
+import gzip
+import pprint
+
+from optparse import OptionParser
+from os import listdir
+
+ssl._create_default_https_context = ssl._create_unverified_context # pylint: disable=W0212
+
+NOW = int(time.time())
+
+pp = pprint.PrettyPrinter(indent=4)
+
+# pfSense is booting, then packages will be reinstalled in the background.
+# Do not make changes in the GUI until this is complete.
+
+class PfSenseWebAPI:
+    def __init__(self):
+        self.browser = mechanize.Browser()
+        self.browser.set_handle_robots(False)
+
+    def login(self,username,password,host):
+        self.username = username
+        self.password = password
+        self.host = host
+        response = self.browser.open('https://' + self.host + '/index.php')
+        self.browser.form = list(self.browser.forms())[0]
+
+        control = self.browser.form.find_control('usernamefld')
+        control.value = self.username
+
+        control = self.browser.form.find_control('passwordfld')
+        control.value = self.password
+
+        response = self.browser.submit()
+
+    def snort_enable(self):
+        for link in self.browser.links():
+            if 'Snort' in link.text:
+                print "Found link " + link.url
+                self.browser.click_link(link)
+                response = self.browser.follow_link(link)
+                break
+        self.browser.form = list(self.browser.forms())[0]
+        self.browser.form.set_all_readonly(False)
+
+        # Enable the first interface
+        self.browser.form.find_control("ldel_0").disabled = True
+        self.browser.form.find_control("id").value = '0'
+        self.browser.form.find_control("toggle").value = 'start'
+        self.browser.form.find_control("by2toggle").value = ''
+
+        response = self.browser.submit()
+        request = self.browser.request
+        html = response.read()
+        #print html
+
+        return
+
+    def set_admin_password(self, new_password):
+        response = self.browser.open('https://' + self.host + '/system_usermanager.php?act=edit&userid=0')
+        self.browser.form = list(self.browser.forms())[0]
+        control = self.browser.form.find_control("passwordfld1")
+        control.value = new_password
+        control = self.browser.form.find_control("passwordfld2")
+        control.value = new_password
+
+        response = self.browser.submit(name='save')
+        html = response.read()
+        print html
+
+        return
+
+
+    def squidguard_enable(self):
+        for link in self.browser.links():
+            if 'SquidGuard Proxy Filter' in link.text:
+                self.browser.click_link(link)
+                response = self.browser.follow_link(link)
+                break
+
+        self.browser.form = list(self.browser.forms())[0]
+        self.browser.form.find_control("squidguard_enable").items[0].selected = True
+        response = self.browser.submit(name='submit')
+
+        request = self.browser.request
+        pp.pprint(request.data)
+
+        html = response.read()
+        #    print html
+
+        return
+
+
+    def squidguard_download(self):
+        response = self.browser.open('https://' + self.host + '/squidGuard/squidguard_blacklist.php')
+        self.browser.form = list(self.browser.forms())[0]
+        control = self.browser.form.find_control('blacklist_url')
+        blacklist = control.value
+        print "Found blacklist: " + blacklist
+
+        response = self.browser.submit(name='blacklist_download_start')
+        html = response.read()
+
+        # Start the download
+        response = self.browser.open('https://' + self.host + '/squidGuard/squidguard_blacklist.php?getactivity=yes&blacklist_download_start=yes&blacklist_url=' + blacklist)
+
+        # Block until completed
+        while True:
+            response = self.browser.open('https://' + self.host + '/squidGuard/squidguard_blacklist.php?getactivity=yes')
+            html = response.read()
+            print html
+            if "Blacklist update complete" in html:
+                break
+        return
+
+    def restore_backup(self):
+        for link in self.browser.links():
+            if 'Backup & Restore' in link.text:
+                self.browser.click_link(link)
+                response = self.browser.follow_link(link)
+                break
+
+        #local_file = '/tmp/pfsense-config-1512885035.xml'
+        local_file = '/tmp/pfsense_dmz_config.xml'
+
+        self.browser.form = list(self.browser.forms())[0]
+        self.browser.form.find_control("decrypt").items[0].selected = False
+        self.browser.form.add_file(open(local_file, "rb"), "", 'config.xml')
+        response = self.browser.submit(name='restore')
+        html = response.read()
+        print html
+
+        return
+
+    def download_backup(self):
+        for link in self.browser.links():
+            if 'Backup & Restore' in link.text:
+                self.browser.click_link(link)
+                response = self.browser.follow_link(link)
+                break
+
+        self.browser.form = list(self.browser.forms())[0]
+        self.browser.form.find_control("donotbackuprrd").items[0].selected = False
+        response = self.browser.submit(name='backup')
+        xml = response.read()
+
+        if COMPRESSION:
+            filename = '%s/pfsense-config-%d.xml.gz' % (BACKUPDIR, NOW)
+            output = gzip.open(filename, 'w')
+        else:
+            filename = '%s/pfsense-config-%d.xml' % (BACKUPDIR, NOW)
+            output = open(filename, 'w')
+        output.write(xml)
+        output.close()
+        return
+
+def main():
+    usage = "usage: %prog [options] arg"
+    parser = OptionParser(usage)
+    parser.add_option("-u", "--username", dest="username",
+                      help="login as username")
+    parser.add_option("-p", "--password", dest="password",
+                      help="login with password")
+    parser.add_option("-H", "--host", dest="host",
+                      help="login to pfSense host")
+    parser.add_option("-r", "--restore-backup",
+                      dest="config")
+    parser.add_option("-S", "--enable-squidguard",
+                      action="store_true")
+    parser.add_option("-D", "--squidguard-download",
+                      action="store_true")
+    parser.add_option("-T", "--enable-snort",
+                      action="store_true")
+    parser.add_option("-P", "--set-admin-password",
+                      dest="new_password")
+    parser.add_option("-g", "--download-backup",
+                      action="store_true")
+
+    (opts, args) = parser.parse_args()
+
+    #if len(args) != 1:
+    #    parser.error("incorrect number of arguments")
+    #if opt.verbose:
+    #    print "reading %s..." % options.filename
+
+    api = PfSenseWebAPI()
+    api.login(opts.username, opts.password, opts.host)
+
+    if opts.squidguard_download:
+        api.squidguard_download()
+
+    if opts.enable_squidguard:
+        api.squidguard_enable()
+
+    if opts.new_password:
+        api.set_admin_password(opts.new_password)
+
+    if opts.enable_snort:
+        api.snort_enable()
+
+    if opts.download_backup:
+        download_backup()
+
+#    if opts.restore_backup:
+#        api.restore_backup()
+
+if __name__ == "__main__":
+    main()

--- a/cli.py
+++ b/cli.py
@@ -42,7 +42,14 @@ class PfSenseWebAPI:
         control = self.browser.form.find_control('passwordfld')
         control.value = self.password
 
-        self.browser.submit()
+        response = self.browser.submit()
+        html = response.read()
+
+        if 'Username or Password' in html:
+            result = 1, "Username or Password is incorrect"
+        else:
+            result = 0, "Login OK"
+        return result
 
     def wait_until_ready(self):
         while True:
@@ -211,7 +218,14 @@ def main():
         sys.exit(1)
 
     api = PfSenseWebAPI(opts.debug_level)
-    api.login(opts.username, opts.password, opts.host)
+    status, message = api.login(opts.username, opts.password, opts.host)
+
+    if status is not True:
+        print (message)
+        sys.exit(2)
+    else:
+        print (message)
+        exit(0)
 
     action = args[0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mechanize


### PR DESCRIPTION
## what
* Implement support for restore/backup of config
* Implement admin password reset
* Implement snort interface enablement
* Implement squidGuard download
* Implement squidGuard enablement

## why
* Restoring the `config.xml` is *never* enough with pfSense
* Many actions only work through web UI
* No easy to way to use configuration management (e.g. ansible) to restore settings in pfSense due to the way files are manipulated through the UI
